### PR TITLE
merge C/C++ API to get variable names

### DIFF
--- a/llvm/include/llvm-c/DebugInfo.h
+++ b/llvm/include/llvm-c/DebugInfo.h
@@ -1148,6 +1148,14 @@ LLVMMetadataRef LLVMDIBuilderCreateGlobalVariableExpression(
 LLVMMetadataRef LLVMDIGlobalVariableExpressionGetVariable(LLVMMetadataRef GVE);
 
 /**
+ * Get the metadata of the file associated with a given variable.
+ * \param Var     The variable object.
+ *
+ * @see DIVariable::getName()
+ */
+const char *LLVMDIVariableGetName(LLVMMetadataRef Var);
+
+/**
  * Retrieves the \c DIExpression associated with this global variable expression.
  * \param GVE    The global variable expression.
  *

--- a/llvm/lib/IR/DebugInfo.cpp
+++ b/llvm/lib/IR/DebugInfo.cpp
@@ -1479,6 +1479,11 @@ unsigned LLVMDIVariableGetLine(LLVMMetadataRef Var) {
   return unwrapDI<DIVariable>(Var)->getLine();
 }
 
+const char *LLVMDIVariableGetName(LLVMMetadataRef Var) {
+  StringRef Str = unwrapDI<DIVariable>(Var)->getName();
+  return Str.data();
+}
+
 LLVMMetadataRef LLVMTemporaryMDNode(LLVMContextRef Ctx, LLVMMetadataRef *Data,
                                     size_t Count) {
   return wrap(


### PR DESCRIPTION
To resolve issue #8 
The added code is tested with `llvm-14` by compiling the whole `llvm`.
