### PR TITLE
C-Binding for Alias Analysis

### DIFF
--- a/llvm/cmake/ClangFormat.cmake
+++ b/llvm/cmake/ClangFormat.cmake
@@ -6,8 +6,18 @@
 ####################################################################
 
 file(GLOB_RECURSE SOURCE_FILES
-  ${PROJECT_SOURCE_DIR}/src/*.cpp
-  ${PROJECT_SOURCE_DIR}/src/*.h)
+  ${LLVM_MAIN_SRC_DIR}/include/*/*.h
+  ${LLVM_MAIN_SRC_DIR}/include/*/*.h
+  ${LLVM_MAIN_SRC_DIR}/include/*/*/*.h
+  ${LLVM_MAIN_SRC_DIR}/lib/*/*.h
+  ${LLVM_MAIN_SRC_DIR}/lib/*/*.cpp
+  ${LLVM_MAIN_SRC_DIR}/lib/*/*.h
+  ${LLVM_MAIN_SRC_DIR}/lib/*/*.cpp
+  ${LLVM_MAIN_SRC_DIR}/lib/*/*/*.h
+  ${LLVM_MAIN_SRC_DIR}/lib/*/*/*.cpp
+  ${LLVM_MAIN_SRC_DIR}/lib/*/*/*/*.h
+  ${LLVM_MAIN_SRC_DIR}/lib/*/*/*/*.cpp
+  )
 
 # # debugging
 # foreach (FILE ${SOURCE_FILES})

--- a/llvm/include/llvm-c/Analysis.h
+++ b/llvm/include/llvm-c/Analysis.h
@@ -37,6 +37,21 @@ typedef enum {
   LLVMReturnStatusAction  /* verifier will just return 1 */
 } LLVMVerifierFailureAction;
 
+typedef enum {
+  /// The two locations do not alias at all.
+  LLVMNoAlias,
+
+  /// The two locations may or may not alias. This is the least precise
+  /// result.
+  LLVMMayAlias,
+
+  /// The two locations precisely alias each other.
+  LLVMMustAlias,
+
+  /// The two locations alias, but only due to a partial overlap.
+  LLVMPartialAlias,
+} LLVMAliasResult;
+
 /* Verifies that a module is valid, taking the specified action if not.
    Optionally returns a human-readable description of any invalid constructs.
    OutMessage must be disposed with LLVMDisposeMessage. */

--- a/llvm/include/llvm-c/Analysis.h
+++ b/llvm/include/llvm-c/Analysis.h
@@ -37,7 +37,6 @@ typedef enum {
   LLVMReturnStatusAction  /* verifier will just return 1 */
 } LLVMVerifierFailureAction;
 
-
 /* Verifies that a module is valid, taking the specified action if not.
    Optionally returns a human-readable description of any invalid constructs.
    OutMessage must be disposed with LLVMDisposeMessage. */
@@ -59,7 +58,8 @@ void LLVMViewFunctionCFGOnly(LLVMValueRef Fn);
 
    Output is a LLVMAliasResult.
 */
-LLVMAliasResult LLVMBasicAAQuery(LLVMModuleRef Module, char *FuncName, LLVMValueRef V1, LLVMValueRef V2);
+LLVMAliasResult LLVMBasicAAQuery(LLVMModuleRef Module, char *FuncName,
+                                 LLVMValueRef V1, LLVMValueRef V2);
 
 /* Check alias between two pointers using the type-based alias analysis.
    Inputs are the current Module, the FuncName of the current function and the
@@ -67,7 +67,8 @@ LLVMAliasResult LLVMBasicAAQuery(LLVMModuleRef Module, char *FuncName, LLVMValue
 
    Output is a LLVMAliasResult.
 */
-LLVMAliasResult LLVMTypeBasedAAQuery(LLVMModuleRef Module, LLVMValueRef V1, LLVMValueRef V2);
+LLVMAliasResult LLVMTypeBasedAAQuery(LLVMModuleRef Module, LLVMValueRef V1,
+                                     LLVMValueRef V2);
 
 /**
  * @}

--- a/llvm/include/llvm-c/Analysis.h
+++ b/llvm/include/llvm-c/Analysis.h
@@ -74,7 +74,15 @@ void LLVMViewFunctionCFGOnly(LLVMValueRef Fn);
 
    Output is a LLVMAliasResult.
 */
-LLVMAliasResult LLVMBasicAAlias(LLVMModuleRef Module, char *FuncName, LLVMValueRef V1, LLVMValueRef V2);
+LLVMAliasResult LLVMBasicAAQuery(LLVMModuleRef Module, char *FuncName, LLVMValueRef V1, LLVMValueRef V2);
+
+/* Check alias between two pointers using the type-based alias analysis.
+   Inputs are the current Module, the FuncName of the current function and the
+   two pointers V1 and V2 to be checked.
+
+   Output is a LLVMAliasResult.
+*/
+LLVMAliasResult LLVMTypeBasedAAQuery(LLVMModuleRef Module, LLVMValueRef V1, LLVMValueRef V2);
 
 /**
  * @}

--- a/llvm/lib/Analysis/Analysis.cpp
+++ b/llvm/lib/Analysis/Analysis.cpp
@@ -8,30 +8,30 @@
 
 #include "llvm-c/Analysis.h"
 #include "llvm-c/Initialization.h"
+#include "llvm/Analysis/AliasAnalysis.h"
+#include "llvm/Analysis/BasicAliasAnalysis.h"
 #include "llvm/IR/Module.h"
+#include "llvm/IR/Value.h"
 #include "llvm/IR/Verifier.h"
 #include "llvm/InitializePasses.h"
+#include "llvm/Pass.h"
 #include "llvm/PassRegistry.h"
 #include "llvm/Support/raw_ostream.h"
-#include "llvm/Analysis/AliasAnalysis.h"
-#include "llvm/Pass.h"
-#include "llvm/IR/Value.h"
-#include "llvm/Analysis/BasicAliasAnalysis.h"
 
+#include "llvm/IR/DataLayout.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/PassManager.h"
 #include "llvm/IR/Type.h"
-#include "llvm/IR/DataLayout.h"
 
 #include "llvm/Passes/PassBuilder.h"
 #include "llvm/Passes/PassPlugin.h"
 #include "llvm/Support/raw_ostream.h"
 
-#include "llvm/IR/LegacyPassManager.h"
-#include "llvm/Transforms/IPO/PassManagerBuilder.h"
 #include "llvm/Analysis/AssumptionCache.h"
 #include "llvm/Analysis/TypeBasedAliasAnalysis.h"
+#include "llvm/IR/LegacyPassManager.h"
+#include "llvm/Transforms/IPO/PassManagerBuilder.h"
 
 #include <cstring>
 
@@ -139,9 +139,9 @@ LLVMBool LLVMVerifyModule(LLVMModuleRef M, LLVMVerifierFailureAction Action,
 }
 
 LLVMBool LLVMVerifyFunction(LLVMValueRef Fn, LLVMVerifierFailureAction Action) {
-  LLVMBool Result = verifyFunction(
-      *unwrap<Function>(Fn), Action != LLVMReturnStatusAction ? &errs()
-                                                              : nullptr);
+  LLVMBool Result =
+      verifyFunction(*unwrap<Function>(Fn),
+                     Action != LLVMReturnStatusAction ? &errs() : nullptr);
 
   if (Action == LLVMAbortProcessAction && Result)
     report_fatal_error("Broken function found, compilation aborted!");
@@ -163,7 +163,7 @@ void LLVMViewFunctionCFGOnly(LLVMValueRef Fn) {
    Using the basic alias analysis
  */
 LLVMAliasResult LLVMBasicAAQuery(LLVMModuleRef ModuleRef, char *FuncNameStr,
-                              LLVMValueRef VRef1, LLVMValueRef VRef2){
+                                 LLVMValueRef VRef1, LLVMValueRef VRef2) {
   StringRef FuncName = llvm::StringRef(FuncNameStr);
   Value *V1 = unwrap<Value>(VRef1);
   Value *V2 = unwrap<Value>(VRef2);
@@ -186,14 +186,11 @@ LLVMAliasResult LLVMBasicAAQuery(LLVMModuleRef ModuleRef, char *FuncNameStr,
 
   if (aares == llvm::AliasResult::NoAlias) {
     return LLVMNoAlias;
-  }
-  else if (aares == llvm::AliasResult::MayAlias) {
+  } else if (aares == llvm::AliasResult::MayAlias) {
     return LLVMMayAlias;
-  }
-  else if (aares == llvm::AliasResult::MustAlias) {
+  } else if (aares == llvm::AliasResult::MustAlias) {
     return LLVMMustAlias;
-  }
-  else{
+  } else {
     return LLVMMayAlias;
   }
 
@@ -204,7 +201,7 @@ LLVMAliasResult LLVMBasicAAQuery(LLVMModuleRef ModuleRef, char *FuncNameStr,
    Using the typed-based alias analysis
  */
 LLVMAliasResult LLVMTypeBasedAAQuery(LLVMModuleRef ModuleRef,
-                              LLVMValueRef VRef1, LLVMValueRef VRef2){
+                                     LLVMValueRef VRef1, LLVMValueRef VRef2) {
   Value *V1 = unwrap<Value>(VRef1);
   Value *V2 = unwrap<Value>(VRef2);
   Module &M = *unwrap(ModuleRef);
@@ -222,14 +219,11 @@ LLVMAliasResult LLVMTypeBasedAAQuery(LLVMModuleRef ModuleRef,
 
   if (aares == llvm::AliasResult::NoAlias) {
     return LLVMNoAlias;
-  }
-  else if (aares == llvm::AliasResult::MayAlias) {
+  } else if (aares == llvm::AliasResult::MayAlias) {
     return LLVMMayAlias;
-  }
-  else if (aares == llvm::AliasResult::MustAlias) {
+  } else if (aares == llvm::AliasResult::MustAlias) {
     return LLVMMustAlias;
-  }
-  else{
+  } else {
     return LLVMMayAlias;
   }
 


### PR DESCRIPTION
# Description
A binding for checking alias analysis of two pointers using the basic alias analysis, similar to using the option `-basic-aa` in `opt`

Fixes https://github.com/sbip-sg/verazt/issues/51

# How Has This PR Been Tested?

The code is tested separately, similar to [unit_test](https://github.com/sbip-sg/llvm-project/tree/sbip-llvm-14/llvm/unittests) or the [test](https://github.com/sbip-sg/llvm-project/tree/sbip-llvm-14/llvm/test) repositories.

The bitcode sources are from these directories.

# Checklist:

Please ensure that all items are reviewed and checked by the notation: `[x]`.
(The irrelevant items can be stricken through by the notation: `~~ ... ~~`, but
they still need to be checked.)

- [x] Self-review: I have reviewed my code thoroughly before creating the PR.
- [x] Code linting: I have run `make linting` and no error/warning is generated.
- [x] Code formatting: I have run `make format` and reviewed all the changes.
- [x] Comments: I have commented on the hard-to-understand areas in my code.
- [x] Documentation: I have updated new changes to the documentation.
- [x] Unit-tests: I have added the necessary unit tests.

