### PR TITLE
Get variable in a llvm.dbg.declare instruction

### DIFF
--- a/llvm/include/llvm-c/Core.h
+++ b/llvm/include/llvm-c/Core.h
@@ -3273,11 +3273,13 @@ LLVMValueRef LLVMIsATerminatorInst(LLVMValueRef Inst);
  */
 
 /**
+ * SBIP LLVM Project.
  * @see llvm::OverflowingBinaryOperator::hasNoUnsignedWrap()
  */
 LLVMBool LLVMHasNoUnsignedWrap(LLVMValueRef Inst);
 
 /**
+ * SBIP LLVM Project.
  * @see llvm::OverflowingBinaryOperator::hasNoSignedWrap()
  */
 LLVMBool LLVMHasNoSignedWrap(LLVMValueRef Inst);
@@ -3287,12 +3289,14 @@ LLVMBool LLVMHasNoSignedWrap(LLVMValueRef Inst);
  */
 
 /**
+ * SBIP LLVM Project.
  * Decide whether the instruction *Inst* is a signed/unsigned integer
  * Output: -1 means no sign information, 0 is unsigned, 1 is signed
  */
 int LLVMGetSignednessInfo(LLVMValueRef Inst);
 
 /**
+ * SBIP LLVM Project.
  * Get the variable in the llvm.dbg.declare instructions.
  */
 LLVMValueRef LLVMGetDbgDeclareVar(LLVMValueRef Inst);

--- a/llvm/include/llvm-c/Core.h
+++ b/llvm/include/llvm-c/Core.h
@@ -3293,6 +3293,11 @@ LLVMBool LLVMHasNoSignedWrap(LLVMValueRef Inst);
 int LLVMGetSignednessInfo(LLVMValueRef Inst);
 
 /**
+ * Get the variable in the llvm.dbg.declare instructions.
+ */
+LLVMValueRef LLVMGetDbgDeclareVar(LLVMValueRef Inst);
+
+/**
  * @defgroup LLVMCCoreValueInstructionCall Call Sites and Invocations
  *
  * Functions in this group apply to instructions that refer to call

--- a/llvm/lib/IR/Core.cpp
+++ b/llvm/lib/IR/Core.cpp
@@ -2875,6 +2875,8 @@ unsigned LLVMGetNumArgOperands(LLVMValueRef Instr) {
 
 /*--.. Binary instructions .................................................--*/
 
+/// This function is added as a part of LLVM-SBIP customized version.
+/// Note: remove the above line when merge back to LLVM Official.
 LLVMBool LLVMHasNoUnsignedWrap(LLVMValueRef Inst) {
   if (OverflowingBinaryOperator *I =
       dyn_cast<OverflowingBinaryOperator>(unwrap(Inst))) {
@@ -2884,6 +2886,8 @@ LLVMBool LLVMHasNoUnsignedWrap(LLVMValueRef Inst) {
   return false;
 }
 
+/// This function is added as a part of LLVM-SBIP customized version.
+/// Note: remove the above line when merge back to LLVM Official.
 LLVMBool LLVMHasNoSignedWrap(LLVMValueRef Inst) {
   if (OverflowingBinaryOperator *I =
       dyn_cast<OverflowingBinaryOperator>(unwrap(Inst))) {
@@ -2894,7 +2898,10 @@ LLVMBool LLVMHasNoSignedWrap(LLVMValueRef Inst) {
 }
 
 
-/*--.. Get signedness of instructions ......................................--*/
+/*--.. Get signedness information of instructions ..........................--*/
+/// Get the variable in the llvm.dbg.declare instructions.
+/// This function is added as a part of LLVM-SBIP customized version.
+/// Note: remove the above line when merge back to LLVM Official.
 int LLVMGetSignednessInfo(LLVMValueRef Inst) {
   DbgDeclareInst *DDI = dyn_cast<DbgDeclareInst>(unwrap(Inst));
   if (!DDI) {
@@ -2921,7 +2928,9 @@ int LLVMGetSignednessInfo(LLVMValueRef Inst) {
   }
 }
 
-/*-- Get the variable in the llvm.dbg.declare instructions .................--*/
+/// Get the variable in the llvm.dbg.declare instructions
+/// This function is added as a part of LLVM-SBIP customized version.
+/// Note: remove the above line when merge back to LLVM Official.
 LLVMValueRef LLVMGetDbgDeclareVar(LLVMValueRef Inst) {
   DbgDeclareInst *DDI = dyn_cast<DbgDeclareInst>(unwrap(Inst));
   if (!DDI) {

--- a/llvm/lib/IR/Core.cpp
+++ b/llvm/lib/IR/Core.cpp
@@ -2921,6 +2921,17 @@ int LLVMGetSignednessInfo(LLVMValueRef Inst) {
   }
 }
 
+/*-- Get the variable in the llvm.dbg.declare instructions .................--*/
+LLVMValueRef LLVMGetDbgDeclareVar(LLVMValueRef Inst) {
+  DbgDeclareInst *DDI = dyn_cast<DbgDeclareInst>(unwrap(Inst));
+  if (!DDI) {
+    return nullptr;
+  }
+
+  Value *value = DDI->getAddress();
+  return wrap(value);
+}
+
 /*--.. Call and invoke instructions ........................................--*/
 
 unsigned LLVMGetInstructionCallConv(LLVMValueRef Instr) {


### PR DESCRIPTION
# Description

This function is to get varialbe of a `llvm.dbg.declare`
For example: if the input is `call void @llvm.dbg.declare(metadata i16* %1, metadata !14, metadata !DIExpression()), !dbg !16`, this function will output `%1`.

In part to fix https://github.com/sbip-sg/verazt/issues/87

# How Has This PR Been Tested?

Please describe the tests that you ran to verify your changes. Please also note
any relevant details for your test configuration.

- Cases in `benchmarks/c-c++/sv-comp/Juliet-Test-Suite-V1.3/CWE197_Numeric_Truncation_Error`  benchmark with the `numeric-truncation` of `verazt`.

# Checklist:

Please ensure that all items are reviewed and checked by the notation: `[x]`.
(The irrelevant items can be stricken through by the notation: `~~ ... ~~`, but
they still need to be checked.)

- [x] Self-review: I have reviewed my code thoroughly before creating the PR.
- [x] Code formatting: I have run `clang-format` with relevant code.
- [x] Comments: I have commented on the hard-to-understand areas in my code.
- [x] Documentation: I have updated new changes to the documentation.
- ~~[ ] Unit-tests: I have added the necessary unit tests.~~
