### PR TITLE
Get flags from debug information

### DIFF
--- a/llvm/include/llvm-c/DebugInfo.h
+++ b/llvm/include/llvm-c/DebugInfo.h
@@ -1075,6 +1075,15 @@ unsigned LLVMDITypeGetLine(LLVMMetadataRef DType);
 LLVMDIFlags LLVMDITypeGetFlags(LLVMMetadataRef DType);
 
 /**
+ * SBIP LLVM Project.
+ * Get the flags associated with this DISubProgram.
+ * \param SP     The DISubprogram.
+ *
+ * @see DISubprogram::getFlags()
+ */
+LLVMDIFlags LLVMDISubprogramGetFlags(LLVMMetadataRef SP);
+
+/**
  * Create a descriptor for a value range.
  * \param Builder    The DIBuilder.
  * \param LowerBound Lower bound of the subrange, e.g. 0 for C, 1 for Fortran.

--- a/llvm/include/llvm-c/DebugInfo.h
+++ b/llvm/include/llvm-c/DebugInfo.h
@@ -1077,7 +1077,7 @@ LLVMDIFlags LLVMDITypeGetFlags(LLVMMetadataRef DType);
 /**
  * SBIP LLVM Project.
  * Get the flags associated with this DISubProgram.
- * \param SP     The DISubprogram.
+ * \param Subprogram     The DISubprogram.
  *
  * @see DISubprogram::getFlags()
  */

--- a/llvm/include/llvm-c/DebugInfo.h
+++ b/llvm/include/llvm-c/DebugInfo.h
@@ -1081,7 +1081,7 @@ LLVMDIFlags LLVMDITypeGetFlags(LLVMMetadataRef DType);
  *
  * @see DISubprogram::getFlags()
  */
-LLVMDIFlags LLVMDISubprogramGetFlags(LLVMMetadataRef SP);
+LLVMDIFlags LLVMDISubprogramGetFlags(LLVMMetadataRef Subprogram);
 
 /**
  * Create a descriptor for a value range.

--- a/llvm/lib/IR/DebugInfo.cpp
+++ b/llvm/lib/IR/DebugInfo.cpp
@@ -1415,6 +1415,12 @@ LLVMDIFlags LLVMDITypeGetFlags(LLVMMetadataRef DType) {
   return map_to_llvmDIFlags(unwrapDI<DIType>(DType)->getFlags());
 }
 
+/// This function is added as a part of LLVM-SBIP customized version.
+/// Note: remove the above line when merge back to LLVM Official.
+LLVMDIFlags LLVMDISubprogramGetFlags(LLVMMetadataRef Subprogram) {
+  return map_to_llvmDIFlags(unwrapDI<DISubprogram>(Subprogram)->getFlags());
+}
+
 LLVMMetadataRef LLVMDIBuilderGetOrCreateTypeArray(LLVMDIBuilderRef Builder,
                                                   LLVMMetadataRef *Types,
                                                   size_t Length) {


### PR DESCRIPTION
Get flags from debug information to find the information about visibility (public/private) of each function in Solidity programs.